### PR TITLE
Adding simple wildcard filter to Server-Sent Events output type.

### DIFF
--- a/lib/outputs/sse.js
+++ b/lib/outputs/sse.js
@@ -34,9 +34,9 @@ module.exports = function(emitter, argv) {
   
   // post all server sent events to parent
   // not all browsers support CORS headers for SSEs
-  app.get('/iframe', function(req, res) {
+  app.get('/iframe/:filter?', function(req, res) {
     res.send(200, '<script>(' + function(window){
-      var source = new EventSource('./events');
+      var source = new EventSource(window.location.pathname.replace(/\/iframe\//, '/events/'));
       source.onmessage = function(e) {
         window.parent.postMessage(e.data, '*');
       };
@@ -44,7 +44,18 @@ module.exports = function(emitter, argv) {
   });
   
   // events implements SSE
-  app.get('/events', function(req, res) {
+  app.get('/events/:filter?', function(req, res) {
+    
+    var filter;
+    
+    if (req.params.filter) {
+      filter = new RegExp(
+        '^' +
+          req.params.filter
+            .replace(/[-[\]{}()+?.,\\^$|#\s]/g, "\\$&")
+            .replace(/\*/g, '.*') +
+        '$');
+    }
     
     req.socket.setTimeout(Infinity);
     
@@ -57,7 +68,10 @@ module.exports = function(emitter, argv) {
     
     id += 1;
     res.id = id;
-    connections[id] = res;
+    connections[id] = {
+      filter: filter,
+      res: res
+    };
     
     res.on('close', function(){
       delete connections[res.id];
@@ -67,9 +81,13 @@ module.exports = function(emitter, argv) {
   
   // send messages forward to all connected clients
   emitter.on('message', function(obj) {
-    Object.keys(connections).forEach(function(k){
-      connections[k].write('data: ' + JSON.stringify(obj) + '\n\n');
-    });
+    var conn, k;
+    for (k in connections) {
+      conn = connections[k];
+      if (!conn.filter || conn.filter.test(obj.routingKey)) {
+        conn.res.write('data: ' + JSON.stringify(obj) + '\n\n')
+      }
+    }
   });
   
   // kick off express app

--- a/man/watchmen.1
+++ b/man/watchmen.1
@@ -5,7 +5,7 @@
 .P
 .RS 2
 .EX
-watchmen [\-?] [\-i (\-|amqp|heartbeat|REST|redis)] [\-o (\-|amqp|REST|redis)]  
+watchmen [\-h] [\-i (\-|amqp|heartbeat|REST|redis)] [\-o (\-|amqp|REST|redis)]  
          \-i amqp [\-\-ih host] [\-\-ip port] [\-\-iv vhost] [\-\-ie exchange] [\-\-ik routingKey]  
          \-i heartbeat [\-\-id delay] [\-\-ik routingKey]  
          \-i redis [\-\-ih host] [\-\-ip port] [\-\-iv vhost] [\-\-ik routingKey]  


### PR DESCRIPTION
- changing -? to -h for showing help in generated man page
- implementing '*' filter for server sent events in the /events path
- adding filter to iframe CORS shim (passes straight through to /events)
