### PR TITLE
Implementing robust amqp (RabbitMQ) support

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -5,11 +5,11 @@ watchmen(1)
 
 ```sh
 watchmen [-h] [-i (-|amqp|heartbeat|REST|redis)] [-o (-|amqp|REST|redis)]  
-         -i amqp [--ih host] [--ip port] [--iv vhost] [--ie exchange] [--ik routingKey]  
+         -i amqp [--ih host] [--ip port] [--iv vhost] [--ie exchange] [--ik routingKey] [--ib backoff]  
          -i heartbeat [--id delay] [--ik routingKey]  
          -i redis [--ih host] [--ip port] [--iv vhost] [--ik routingKey]  
          -i REST --iu url [--id delay]  
-         -o amqp [--oh host] [--op port] [--ov vhost] [--oe exchange]  
+         -o amqp [--oh host] [--op port] [--ov vhost] [--oe exchange] [--ib backoff]  
          -o redis [--oh host] [--op port] [--ov vhost]  
          -o REST --ou url  
 ```
@@ -32,7 +32,7 @@ Additional input and output options depend on the kind of input or output in use
 
 ## Description
 
-A Swiss Army Knife of input and output piping.
+A Swiss Army Knife for message routing between systems.
 
 ## Options
 
@@ -50,6 +50,7 @@ Inputs:
 	input-host : host name of the RabbitMQ server  
 	input-port : port number of the RabbitMQ service  
 	input-vhost : virtual host for exchange/queue namespacing  
+	input-backoff : time in ms to wait before retrying a failed connection  
 
 `redis` : reads messages from a LIST  
 	input-routing-key : the key to the LIST containing messages  
@@ -70,6 +71,7 @@ Outputs:
 	output-host : host name of the RabbitMQ server  
 	output-port : port number of the RabbitMQ service  
 	output-vhost : virtual host for exchange/queue namespacing  
+	output-backoff : time in ms to wait before retrying a failed connection  
 
 `redis` : appends each message to LIST based on its routingKey  
 	output-host : host name of the Redis server  

--- a/lib/inputs/amqp.js
+++ b/lib/inputs/amqp.js
@@ -9,39 +9,120 @@ var amqp = require('amqp');
 
 module.exports = function(emitter, argv) {
   
-  emitter.on('ready', function(){
-    var
-      options = {},
-      connection;
+  var
     
-    argv['input-host'] && (options.host = argv['input-host']);
-    argv['input-port'] && (options.port = argv['input-port']);
-    argv['input-vhost'] && (options.vhost = argv['input-vhost']);
+    options = {},
     
-    connection = amqp.createConnection(options);
-    connection.once('ready', function () {
-      connection.queue('', {exclusive: true}, function(queue) {
-        queue.bind(argv['input-exchange'], argv['input-routing-key']);
-        queue.subscribe(function(message, headers, deliveryInfo){
-          if (message.data instanceof Buffer) {
-            message = message.data.toString();
-            if (!deliveryInfo.contentType) {
-              try {
-                // no contentType supplied, let's see if it's actually JSON
-                message = JSON.parse(message);
-              } catch (err) {
-                // ignore parse error
-              }
-            }
-          }
-          emitter.emit('message', {
-            routingKey: deliveryInfo.routingKey,
-            message: message
-          });
-        });
-      });
+    connection,
+    exchange,
+    queue,
+    consumerTag,
+    
+    handleMessage,
+    setup,
+    teardown,
+    cycle,
+    timer;
+  
+  argv['input-host'] && (options.host = argv['input-host']);
+  argv['input-port'] && (options.port = argv['input-port']);
+  argv['input-vhost'] && (options.vhost = argv['input-vhost']);
+  
+  /**
+   * when a message arrives, send it up through the provided emitter.
+   */
+  handleMessage = function(message, headers, deliveryInfo){
+    
+    if (message.data instanceof Buffer) {
+      message = message.data.toString();
+      if (!deliveryInfo.contentType) {
+        try {
+          // no contentType supplied, let's see if it's actually JSON
+          message = JSON.parse(message);
+        } catch (err) {
+          // ignore parse error
+        }
+      }
+    }
+    
+    emitter.emit('message', {
+      routingKey: deliveryInfo.routingKey,
+      message: message
     });
     
-  });
+  };
+  
+  /**
+   * establish a connection, create a queue, bind it and subscribe
+   */
+  setup = function(){
+    
+    clearTimeout(timer);
+    timer = null;
+    
+    connection = amqp.createConnection(options, {reconnect: false});
+    
+    // although there could be many errors, there'll be only one close event
+    connection.on('close', cycle);
+    
+    // prevent error events from bubbling up as thrown exceptions
+    connection.on('error', function(err){
+      // design choice: don't cycle from here, only on 'close'
+      // rationale: testing shows that many error events happen for each close event
+      // alternative: call cycle and let the if(!timer) handle scheduling
+    });
+    
+    connection.on('ready', function(){
+      
+      // design choice: create the exchange if it doesn't exist.
+      // rationale: won't miss messages from publisher during poll delay
+      // alternative: wait for exchange to exist (may miss more messages)
+      connection.exchange(argv['input-exchange'], {}, function (ex) {
+        exchange = ex;
+        connection.queue('', {exclusive: true}, function(q) {
+          queue = q;
+          queue.bind(exchange, argv['input-routing-key']);
+          queue
+            .subscribe(handleMessage)
+            .addCallback(function(ok){
+              consumerTag = ok.consumerTag;
+            }); 
+        });
+      });
+      
+    });
+    
+  };
+  
+  /**
+   * clean up after a closed/failed connection
+   */
+  teardown = function() {
+    if (queue && consumerTag) {
+      queue.unsubscribe(consumerTag);
+      queue = consumerTag = null;
+    }
+    if (exchange) {
+      exchange = null;
+    }
+    if (connection) {
+      connection.removeAllListeners();
+      connection.end();
+      connection = null;
+    }
+  };
+  
+  /**
+   * cycle the connection and try again
+   */
+  cycle = function() {
+    if (!timer) {
+      teardown();
+      setTimeout(setup, argv['input-backoff']);
+    }
+  };
+  
+  // make first connection attempt once the output is ready
+  emitter.once('ready', setup);
   
 };

--- a/lib/options.js
+++ b/lib/options.js
@@ -27,12 +27,14 @@ module.exports = function(args) {
       'id': 'input-delay',
       'ik': 'input-routing-key',
       'ie': 'input-exchange',
+      'ib': 'input-backoff',
       'o': 'output',
       'oh': 'output-host',
       'op': 'output-port',
       'ov': 'output-vhost',
       'ou': 'output-url',
       'oe': 'output-exchange',
+      'ob': 'output-backoff',
       'h': 'help'
     })
     .describe({
@@ -44,12 +46,14 @@ module.exports = function(args) {
       'iv': 'virtual host for exchange/queue namespacing (amqp only).',
       'ie': 'the exchange to bind to for receiving messages (amqp only).',
       'iu': 'the URL to poll for changes (REST only).',
-      'id': 'time in milliseconds to delay for polling attempts/heartbeats.',
+      'id': 'time in ms to delay for polling attempts/heartbeats.',
+      'ib': 'time in ms to wait before retrying a connection (amqp only)',
       'oh': 'hostname of message destination.',
       'op': 'port number of the service.',
       'ov': 'virtual host for exchange/queue namespacing (amqp only).',
       'oe': 'the exchange to publish messages to (amqp only).',
       'ou': 'the url to POST messages to (REST only).',
+      'ob': 'time in ms to wait before retrying a connection (amqp only)',
       'h': 'print this help'
     })
     .default({
@@ -60,11 +64,13 @@ module.exports = function(args) {
       'id': 10000,
       'ik': '#',
       'ie': exchangeDefault,
+      'ib': 1000,
       'o': '-',
       'oh': hostDefault,
       'op': portDefault,
       'ov': vhostDefault,
-      'oe': exchangeDefault
+      'oe': exchangeDefault,
+      'ob': 1000
     })
     .check(function(argv){
       if (!(argv.input in inputs)) {

--- a/lib/outputs/amqp.js
+++ b/lib/outputs/amqp.js
@@ -10,21 +10,81 @@ var amqp = require('amqp');
 module.exports = function(emitter, argv) {
   
   var
+    
     options = {},
-    connection;
+    
+    connection,
+    exchange,
+    timer,
+    
+    setup,
+    teardown,
+    cycle;
     
   argv['output-host'] && (options.host = argv['output-host']);
   argv['output-port'] && (options.port = argv['output-port']);
   argv['output-vhost'] && (options.vhost = argv['output-vhost']);
   
-  connection = amqp.createConnection(options);
-  connection.once('ready', function () {
-    connection.exchange(argv['output-exchange'], {}, function (exchange) {
-      emitter.on('message', function(obj){
-        exchange.publish(obj.routingKey, obj.message, {});
+  /**
+   * establish a connection, create an exchange
+   */
+  setup = function() {
+    
+    clearTimeout(timer);
+    timer = null;
+    
+    connection = amqp.createConnection(options, {reconnect: false});
+    
+    // the connection may become ready many times
+    // the amqp library has a built-in retry mechanism
+    connection.on('ready', function () {
+      connection.exchange(argv['output-exchange'], {}, function (ex) {
+        exchange = ex;
+        emitter.emit('ready');
       });
-      emitter.emit('ready');
     });
+    
+    // when the connection closes, cycle everything
+    connection.on('close', cycle);
+    
+    // prevent error events from bubbling up as thrown exceptions
+    connection.on('error', function(err){
+      // design choice: don't cycle from here, only on 'close'
+      // rationale: testing shows that many error events happen for each close event
+      // alternative: call cycle and let the if(!timer) handle scheduling
+    });
+  };
+  
+  /**
+   * clean up after a closed/failed connection
+   */
+  teardown = function() {
+    exchange = null;
+    if (connection) {
+      connection.removeAllListeners();
+      connection.end();
+      connection = null;
+    }
+  };
+  
+  /**
+   * cycle the connection and try again
+   */
+  cycle = function() {
+    if (!timer) {
+      teardown();
+      setTimeout(setup, argv['output-backoff']);
+    }
+  };
+  
+  // forward any messages to the exchange, if one is available
+  emitter.on('message', function(obj){
+    if (exchange) {
+      exchange.publish(obj.routingKey, obj.message, {});
+    }
   });
+  
+  // make first connection attempt
+  setup();
   
 };


### PR DESCRIPTION
- added input-backoff and output-backoff options to specify retry delays (both default to one second)
- amqp input and output now perform their own reconnection logic instead of relying on node-amqp
