### PR TITLE
add in leveldb persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.swp
+persistence

--- a/lib/level.js
+++ b/lib/level.js
@@ -1,0 +1,35 @@
+var
+  level = require('level'),
+  express = require('express'),
+  cors = require('cors');
+
+module.exports = function(emitter) {
+  var db = level('./persistence');
+
+  emitter.on('message', function(data) {
+    var date = (new Date()).toISOString();
+    db.put(date, JSON.stringify(data), function(err) {
+      if (err) {
+        console.error(error);
+      }
+    });
+  });
+
+  var app = express();
+
+  //app.use(cors);
+  app.get('/', function(req, res) {
+    res.end(404);
+  });
+  app.get('/:date', function(req, res) {
+    var d = [];
+    db.createReadStream({start: req.params.date})
+      .on('data', function(data) {
+        d.push(JSON.parse(data.value));
+      })
+      .on('end', function() {
+        res.send(d);
+      });
+  });
+  app.listen('5555');
+}

--- a/lib/level.js
+++ b/lib/level.js
@@ -17,7 +17,7 @@ module.exports = function(emitter) {
 
   var app = express();
 
-  //app.use(cors);
+  app.use(cors);
   app.get('/', function(req, res) {
     res.end(404);
   });

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,7 +9,8 @@
 var
   EventEmitter = require('events').EventEmitter,
   inputs = require('./inputs/index.js'),
-  outputs = require('./outputs/index.js');
+  outputs = require('./outputs/index.js'),
+  levelwrapper = require('./level.js');
 
 /**
  * Main function.
@@ -19,6 +20,10 @@ var
 module.exports = function(argv) {
   
   var emitter = new EventEmitter();
+
+  if (argv.persist) {
+    levelwrapper(emitter);
+  }
   
   inputs[argv.input](emitter, argv);
   outputs[argv.output](emitter, argv);

--- a/lib/options.js
+++ b/lib/options.js
@@ -33,6 +33,7 @@ module.exports = function(args) {
       'ov': 'output-vhost',
       'ou': 'output-url',
       'oe': 'output-exchange',
+      'p': 'persist',
       'h': 'help'
     })
     .describe({
@@ -50,6 +51,7 @@ module.exports = function(args) {
       'ov': 'virtual host for exchange/queue namespacing (amqp only).',
       'oe': 'the exchange to publish messages to (amqp only).',
       'ou': 'the url to POST messages to (REST only).',
+      'p': 'Persist the data to a db and have it available to be queriable via http',
       'h': 'print this help'
     })
     .default({
@@ -64,7 +66,8 @@ module.exports = function(args) {
       'oh': hostDefault,
       'op': portDefault,
       'ov': vhostDefault,
-      'oe': exchangeDefault
+      'oe': exchangeDefault,
+      'p': false
     })
     .check(function(argv){
       if (!(argv.input in inputs)) {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "optimist": "~0.6.0",
     "redis": "~0.8.4",
     "request": "~2.22",
-    "express": "~3.3.4"
+    "express": "~3.3.4",
+    "level": "~0.16.0",
+    "cors": "~1.0.1"
   },
   "devDependencies": {
     "marked-man": "0.0.2"


### PR DESCRIPTION
When given the `-p` command, it'll persist all messages into a leveldb. It's then queryable by date on port `5555`.
Fixes #9 
It needs is better handling of the query. Also, perhaps better ways of storing the data. Currently, I just store each item by date, but it might be good to have it store it via date and routing key.
